### PR TITLE
Add getAccountInfo method

### DIFF
--- a/src/lib/types/all-methods.js
+++ b/src/lib/types/all-methods.js
@@ -1,4 +1,16 @@
 export const methods = {
+    getAccountInfo: {
+        name: "getAccountInfo",
+        defaultParams: {
+            pubkey: "2k5AXX4guW9XwRQ1AKCpAuUqgWDpQpwFfpVFh3hnm2Ha", 
+        },
+        optionalParams: {
+            commitment: "confirmed",
+            minContextSlot: 0,
+        },
+        paramsFormat: "array",
+        paramsStructure: ["pubkey"],
+    },
     getAsset: {
         name: "getAsset",
         defaultParams: {


### PR DESCRIPTION
Adds the `getAccountInfo` method, which I miss on the Playground.

I did not add the [optional parameters](https://docs.solana.com/api/http#getaccountinfo) `dataSlice` and `endcoding`, since I think they're not useful here.