### PR TITLE
fix: Params not Passed for Method `getBlockHeight`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "// Lint": "-------------------------------------------------------------",
         "test": "npm run lint",
         "lint": "eslint . --fix",
-        "format": "prettier --write '{public,src}/**/*.{css,html,js,svelte}'",
+        "format": "prettier --write \"{public,src}/**/*.{css,html,js,svelte}\"",
         "prepare": "husky install"
     },
     "lint-staged": {

--- a/src/lib/types/all-methods.js
+++ b/src/lib/types/all-methods.js
@@ -1,3 +1,14 @@
+/**
+ * @typedef {{
+ *     name: string;
+ *     defaultParams: Record<string, string | number | object>;
+ *     optionalParams?: [] | Record<string, string | number | boolean | null>;
+ *     paramsFormat: "object" | "array" | "none";
+ *     paramsStructure?: string[];
+ * }} RpcMethod
+ */
+
+/** @type Record<string, RpcMethod> */
 export const methods = {
     getAccountInfo: {
         defaultParams: {

--- a/src/lib/types/all-methods.js
+++ b/src/lib/types/all-methods.js
@@ -128,6 +128,7 @@ export const methods = {
         defaultParams: {},
         name: "getBlockHeight",
         optionalParams: { commitment: "confirmed", minContextSlot: 0 },
+        paramsFormat: "array",
     },
     getBlockProduction: {
         defaultParams: {},

--- a/src/lib/types/method-dev.js
+++ b/src/lib/types/method-dev.js
@@ -1,3 +1,5 @@
+/** @typedef {import("./all-methods").RpcMethod} RpcMethod */
+/** @type Record<string, RpcMethod> */
 export const methods = {
     getAsset: {
         defaultParams: {

--- a/src/lib/types/method-dev.js
+++ b/src/lib/types/method-dev.js
@@ -130,6 +130,7 @@ export const methods = {
         defaultParams: {},
         name: "getBlockHeight",
         optionalParams: { commitment: "confirmed", minContextSlot: 0 },
+        paramsFormat: "object",
     },
     getBlockProduction: {
         defaultParams: {},


### PR DESCRIPTION
The method description for `getBlockHeight` did not contain the `paramsFormat` key, so the parameters were never set even if they were changed in the UI.
This PR also adds a type `RpcMethod` and sets the type of the methods array via a jsdoc comment to ensure this doesn't happen again.